### PR TITLE
When no LCD display is attached AND when printing from SD card, go ahead...

### DIFF
--- a/firmware/src/Motherboard/Command.cc
+++ b/firmware/src/Motherboard/Command.cc
@@ -240,6 +240,10 @@ enum ModeState {
 #endif
 };
 
+#ifdef HAS_INTERFACE_BOARD
+static bool hasInterfaceBoard = false;
+#endif
+
 enum ModeState mode = READY;
 
 Timeout delay_timeout;
@@ -282,6 +286,10 @@ void reset() {
 	if (( eeprom::getEeprom8(eeprom::TOOL_COUNT, 1) == 2 ) && ( eeprom::getEeprom8(eeprom::DITTO_PRINT_ENABLED, EEPROM_DEFAULT_DITTO_PRINT_ENABLED) ))
 		dittoPrinting = true;
 	else	dittoPrinting = false;
+#endif
+
+#ifdef HAS_INTERFACE_BOARD
+	hasInterfaceBoard = Motherboard::getBoard().hasInterface();
 #endif
 
 	mode = READY;
@@ -946,6 +954,14 @@ void runCommandSlice() {
 			sd_count++;
 			command_buffer.push(sdcard::playbackNext());
 		}
+#ifdef HAS_INTERFACE_BOARD
+		if ( !sdcard::playbackHasNext() && !hasInterfaceBoard )
+#else
+		if ( !sdcard::playbackHasNext() )
+#endif
+			// sdcard::isPlaying() will continue to return true
+			//   until we finish the playback
+			sdcard::finishPlayback();
 	}
 
 #ifdef PAUSEATZPOS

--- a/firmware/src/Motherboard/SDCard.cc
+++ b/firmware/src/Motherboard/SDCard.cc
@@ -410,6 +410,7 @@ void finishPlayback() {
 	if ( !playing ) return;
 	finishFile();
 	playing = false;
+	has_more = false;
 }
 
 

--- a/firmware/src/Motherboard/boards/mb24/Motherboard.cc
+++ b/firmware/src/Motherboard/boards/mb24/Motherboard.cc
@@ -79,6 +79,7 @@ Motherboard::Motherboard() :
             LCD_D1_PIN,
             LCD_D2_PIN,
             LCD_D3_PIN),
+	hasInterfaceBoard(false),
 	messageScreen(),
 	moodLightController(SOFTWARE_I2C_SDA_PIN,
 		  	    SOFTWARE_I2C_SCL_PIN),

--- a/firmware/src/Motherboard/boards/mb24/Motherboard.hh
+++ b/firmware/src/Motherboard/boards/mb24/Motherboard.hh
@@ -146,6 +146,8 @@ public:
 
         /// update microsecond counter
         void UpdateMicros();
+
+	bool hasInterface() { return hasInterfaceBoard; }
 };
 
 #endif // SIMULATOR

--- a/firmware/src/Motherboard/boards/rrmbv12-2560/Motherboard.hh
+++ b/firmware/src/Motherboard/boards/rrmbv12-2560/Motherboard.hh
@@ -80,6 +80,8 @@ public:
 	/// Used on for rrmbv12-2560, this only sets the buzzer on, never off
 	void buzz(uint8_t buzzes, uint8_t duration, uint8_t repeats);
 	void stopBuzzer();
+
+	bool hasInterface() { return false; }
 };
 
 #endif // BOARDS_RRMBV12_MOTHERBOARD_HH_

--- a/firmware/src/Motherboard/boards/rrmbv12/Motherboard.hh
+++ b/firmware/src/Motherboard/boards/rrmbv12/Motherboard.hh
@@ -76,6 +76,8 @@ public:
         void doAdvanceInterrupt();
 	
 	void UpdateMicros();
+
+	bool hasInterface() { return false; }
 };
 
 #endif // BOARDS_RRMBV12_MOTHERBOARD_HH_


### PR DESCRIPTION
... and call sdcard::finishPlayback() so that sdcard::isPlaying() will return false and the host state will return to HOST_STATE_READY rather then remain at HOST_STATE_BUILDING_FROM_SD.  When there is an LCD display, we prefer to stay at H_S_B_FROM_SD so that the user has a chance to 'print another'.
