### PR TITLE
Make the speed control menu an optional build item.  Works fine; however...

### DIFF
--- a/firmware/src/Motherboard/Command.cc
+++ b/firmware/src/Motherboard/Command.cc
@@ -410,7 +410,9 @@ void platformAccess(bool clearPlatform) {
 	else				targetPosition[A_AXIS] = targetPosition[B_AXIS];
    }
 #endif
-
+#ifdef SPEED_CONTROL
+   steppers::alterSpeed = 0;
+#endif
    steppers::setTargetNewExt(targetPosition, dda_rate, (uint8_t)0, distance, FPTOI16(stepperAxis[Z_AXIS].max_feedrate << 6));
 }
 
@@ -719,7 +721,12 @@ static void handleMovementCommand(const uint8_t &command) {
 #endif
 
 			line_number++;
-			steppers::setTargetNewExt(Point(x,y,z,a,b), dda_rate, relative | steppers::alterSpeed,
+			steppers::setTargetNewExt(Point(x,y,z,a,b), dda_rate,
+#ifdef SPEED_CONTROL
+						  relative | steppers::alterSpeed,
+#else
+						  relative,
+#endif
 						  *distance, feedrateMult64);
 		}
 	}

--- a/firmware/src/Motherboard/StepperAccelPlanner.cc
+++ b/firmware/src/Motherboard/StepperAccelPlanner.cc
@@ -1236,7 +1236,7 @@ void plan_buffer_line(FPTYPE feed_rate, const uint32_t &dda_rate, const uint8_t 
 		// Calculate speed in mm/sec for each axis
 		for (unsigned char i=0; i < STEPPER_COUNT; i++)
 			current_speed[i] = FPMULT2(delta_mm[i], inverse_second);
-#ifdef HAS_INTERFACE_BOARD
+#if defined(HAS_INTERFACE_BOARD) && defined(SPEED_CONTROL)
 		// If the user has changed the print speed dynamically, then ensure that
 		//   the maximum feedrate limits are observed 
 		if ( block->use_accel && steppers::alterSpeed ) {

--- a/firmware/src/Motherboard/Steppers.cc
+++ b/firmware/src/Motherboard/Steppers.cc
@@ -71,8 +71,11 @@ volatile bool is_homing;
 bool acceleration = true;
 uint8_t plannerMaxBufferSize;
 FPTYPE axis_steps_per_unit_inverse[STEPPER_COUNT];
+
+#ifdef SPEED_CONTROL
 FPTYPE speedFactor = KCONSTANT_1;
 uint8_t alterSpeed = 0x00;
+#endif
 
 // Some gcode is loaded with enable/disable extruder commands. E.g., before each travel-only move.
 // This seems okay for 1.75 mm filament extruders.  However, it is problematic for 3mm filament
@@ -519,8 +522,10 @@ void reset() {
 	plannerMaxBufferSize = BLOCK_BUFFER_SIZE - 1;
 #endif
 
+#ifdef SPEED_CONTROL
 	alterSpeed  = 0x00;
 	speedFactor = KCONSTANT_1;
+#endif
 
 	plan_init(advanceK, advanceK2, holdZ);		//Initialize planner
 	st_init();					//Initialize stepper accel
@@ -803,7 +808,8 @@ void setTargetNewExt(const Point& target, int32_t dda_rate, uint8_t relative, fl
 #else
 		feedrate /= 64.0;
 #endif
-#ifdef HAS_INTERFACE_BOARD
+
+#if defined(HAS_INTERFACE_BOARD) && defined(SPEED_CONTROL)
 		if ( relative & 0x80 ) {
 			feedrate = FPMULT2(feedrate, speedFactor);
 			dda_rate = (int32_t)((float)dda_rate * FPTOF(speedFactor));

--- a/firmware/src/Motherboard/Steppers.hh
+++ b/firmware/src/Motherboard/Steppers.hh
@@ -45,8 +45,10 @@ namespace steppers {
     extern bool acceleration;
     extern FPTYPE axis_steps_per_unit_inverse[STEPPER_COUNT];
     extern bool extruder_hold[EXTRUDERS];
+#ifdef SPEED_CONTROL
     extern uint8_t alterSpeed;
     extern FPTYPE speedFactor;
+#endif
 
     /// Check if the stepper subsystem is running
     /// \return True if the stepper subsystem is running or paused. False

--- a/firmware/src/Motherboard/boards/mb24/Configuration.hh
+++ b/firmware/src/Motherboard/boards/mb24/Configuration.hh
@@ -329,4 +329,7 @@
 // Our software variant id for the advanced version command
 #define SOFTWARE_VARIANT_ID 0x80
 
+// Enable speed control menu
+//#define SPEED_CONTROL
+
 #endif // BOARDS_RRMBV12_CONFIGURATION_HH_

--- a/firmware/src/Motherboard/boards/rrmbv12-2560/Configuration.hh
+++ b/firmware/src/Motherboard/boards/rrmbv12-2560/Configuration.hh
@@ -291,4 +291,7 @@
 // Our software variant id for the advanced version command
 #define SOFTWARE_VARIANT_ID 0x80
 
+// Enable speed control menu (requires an LCD interface)
+//#define SPEED_CONTROL
+
 #endif // BOARDS_RRMBV12_CONFIGURATION_HH_

--- a/firmware/src/Motherboard/boards/rrmbv12/Configuration.hh
+++ b/firmware/src/Motherboard/boards/rrmbv12/Configuration.hh
@@ -284,4 +284,7 @@
 // Our software variant id for the advanced version command
 #define SOFTWARE_VARIANT_ID 0x80
 
+// Enable speed control menu  (Requires an LCD interface)
+//#define SPEED_CONTROL
+
 #endif // BOARDS_RRMBV12_CONFIGURATION_HH_

--- a/firmware/src/shared/Menu.cc
+++ b/firmware/src/shared/Menu.cc
@@ -1483,7 +1483,11 @@ void CancelBuildMenu::resetState() {
 		itemCount = 4;
 	} else {
 		itemIndex = 1;
+#ifdef SPEED_CONTROL
+		itemCount = 8;
+#else
 		itemCount = 7;
+#endif
 	}
 
 	if ( printAnotherEnabled ) {
@@ -1505,7 +1509,9 @@ void CancelBuildMenu::drawItem(uint8_t index, LiquidCrystal& lcd) {
 	const static PROGMEM prog_uchar cb_abort[]		= "Abort Print   ";
 	const static PROGMEM prog_uchar cb_printAnother[]	= "Print Another ";
 	const static PROGMEM prog_uchar cb_pauseZ[]		= "Pause at ZPos ";
+#ifdef SPEED_CONTROL
 	const static PROGMEM prog_uchar cb_speed[]              = "Change Speed";
+#endif
 	const static PROGMEM prog_uchar cb_pause[]		= "Pause         ";
 	const static PROGMEM prog_uchar cb_pauseHBPHeat[]	= "Pause, HBP on ";
 	const static PROGMEM prog_uchar cb_pauseNoHeat[]	= "Pause, No Heat";
@@ -1535,10 +1541,12 @@ void CancelBuildMenu::drawItem(uint8_t index, LiquidCrystal& lcd) {
 		lind ++;
 	}
 
+#ifdef SPEED_CONTROL
 	if ( ! pauseDisabled ) {
 		if ( index == lind )	lcd.writeFromPgmspace(LOCALIZE(cb_speed));
 		lind ++;
 	}
+#endif
 
 	if ( ! pauseDisabled ) {
 		if ( index == lind )	lcd.writeFromPgmspace(LOCALIZE(cb_pause));
@@ -1598,6 +1606,7 @@ void CancelBuildMenu::handleSelect(uint8_t index) {
 		lind ++;
 	}
 
+#ifdef SPEED_CONTROL
 	if ( ! pauseDisabled ) {
 		if ( index == lind )
 		{
@@ -1606,6 +1615,7 @@ void CancelBuildMenu::handleSelect(uint8_t index) {
 		}
 		lind ++;
 	}
+#endif
 
 	if ( ! pauseDisabled ) {
 		if ( index == lind ) {
@@ -2523,6 +2533,7 @@ void PauseAtZPosScreen::notifyButtonPressed(ButtonArray::ButtonName button) {
 	if ( pauseAtZPos < 0.001 )	pauseAtZPos = 0.0;
 }
 
+#ifdef SPEED_CONTROL
 void ChangeSpeedScreen::reset() {
 	// So that we can restore the speed in case of a CANCEL
 	speedFactor = steppers::speedFactor;
@@ -2589,6 +2600,8 @@ void ChangeSpeedScreen::notifyButtonPressed(ButtonArray::ButtonName button) {
 	steppers::alterSpeed  = (sf == KCONSTANT_1) ? 0x00 : 0x80;
 	steppers::speedFactor = sf;
 }
+
+#endif // SPEED_CONTROL
 
 void AdvanceABPMode::reset() {
 	abpForwarding = false;

--- a/firmware/src/shared/Menu.hh
+++ b/firmware/src/shared/Menu.hh
@@ -8,7 +8,10 @@
 #include "CircularBuffer.hh"
 #include "Timeout.hh"
 #include "Command.hh"
+
+#ifdef SPEED_CONTROL
 #include "StepperAccelPlanner.hh"
+#endif
 
 /// The screen class defines a standard interface for anything that should
 /// be displayed on the LCD.
@@ -249,6 +252,8 @@ public:
 };
 
 
+#ifdef SPEED_CONTROL
+
 class ChangeSpeedScreen: public Screen {
 private:
 	uint8_t alterSpeed;
@@ -264,6 +269,7 @@ public:
         void notifyButtonPressed(ButtonArray::ButtonName button);
 };
 
+#endif
 
 class CancelBuildMenu: public Menu {
 public:
@@ -281,7 +287,9 @@ private:
 	PauseMode		pauseMode;
 	bool			pauseDisabled;
 	PauseAtZPosScreen	pauseAtZPosScreen;
+#ifdef SPEED_CONTROL
 	ChangeSpeedScreen       changeSpeedScreen;
+#endif
 	bool			printAnotherEnabled;
 };
 


### PR DESCRIPTION
..., seems pointless since Sailfish produces very fine quality at all speeds and doesn't have issues with the acceleration planner queue running dry in regions of fine detail owing to having an accel planner which is 5x faster than Marlin since it doesn't use floating point math.  And then another 2x speedup when fed accelerated move commands with some key data pre-computed.  To enable the speed control menu, uncomment the #define SPEED_CONTROL in Configuration.hh
