### PR TITLE
During a print, the running total of filament used should be the sum of ...

### DIFF
--- a/firmware/src/shared/Menu.cc
+++ b/firmware/src/shared/Menu.cc
@@ -1248,9 +1248,9 @@ void MonitorMode::update(LiquidCrystal& lcd, bool forceRedraw) {
 				lcd.setRow(1);
 				lcd.writeFromPgmspace(LOCALIZE(mon_filament));
 				lcd.setCursor(9,1);
-				lastFilamentUsed = stepperAxisStepsToMM(command::getLastFilamentLength(0) + command::getLastFilamentLength(1), A_AXIS);
-				if ( lastFilamentUsed != 0.0 )	filamentUsed = lastFilamentUsed;
-				else				filamentUsed = stepperAxisStepsToMM((command::getFilamentLength(0) + command::getFilamentLength(1)), A_AXIS);
+				filamentUsed =
+				     stepperAxisStepsToMM(command::getLastFilamentLength(0) + command::getLastFilamentLength(1), A_AXIS) +
+				     stepperAxisStepsToMM((command::getFilamentLength(0) + command::getFilamentLength(1)), A_AXIS);
 				filamentUsed /= 1000.0;	//convert to meters
 				if	( filamentUsed < 0.1 )	{
 					 filamentUsed *= 1000.0;	//Back to mm's


### PR DESCRIPTION
...lastFilamentLength and filamentLength.  It should not be lastFilamentLength when non-zero and filamentLength otherwise.  To demonstrate, extrude a little plastic, then set the extruder temp to 0, then re-heat it and continue extruding.  Setting temp to 0 then makes lastFilamentLength be the amount extruded only up until the extruder was turned off.
